### PR TITLE
Fix Chapter 11 code for realTimeDataBase with FireStore

### DIFF
--- a/chapter-11/petstore/src/components/Main.vue
+++ b/chapter-11/petstore/src/components/Main.vue
@@ -58,7 +58,8 @@ export default {
   },
   data () {
     return {
-      cart: []
+      cart: [],
+      products: [],
     }
   },
   components: { MyHeader },

--- a/chapter-11/petstore/src/main.js
+++ b/chapter-11/petstore/src/main.js
@@ -1,15 +1,16 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'
+import { rtdbPlugin } from 'vuefire';
 import App from './App'
 import router from './router'
 require('./assets/app.css')
 import { store } from './store/store';
 import firebase from 'firebase';
 import './firebase';
-import VueFire from 'vuefire';
 
-Vue.use(VueFire);
+
+Vue.use(rtdbPlugin);
 Vue.config.productionTip = false
 
 /* eslint-disable no-new */


### PR DESCRIPTION
#### Include Import statement for rtdbPlugin in main.js file
#### Declarative binding:
Declare property `products` to its initial value as an empty array in `data` for binding